### PR TITLE
Add initial MCP server implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+*.log
+.env
+.env.local
+.DS_Store
+Thumbs.db
+*.tmp
+*.temp

--- a/claude_mcp_config.json
+++ b/claude_mcp_config.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "godot-screenshot": {
+      "command": "node",
+      "args": ["/path/to/godot-screenshot-mcp/dist/index.js"]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1088 @@
+{
+  "name": "godot-screenshot-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "godot-screenshot-server",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.1",
+        "zod": "^3.22.4"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.1",
+        "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.3.tgz",
+      "integrity": "sha512-DyVYSOafBvk3/j1Oka4z5BWT8o4AFmoNyZY9pALOm7Lh3GZglR71Co4r4dEUoqDWdDazIZQHBe7J2Nwkg6gHgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.0.tgz",
+      "integrity": "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.2.tgz",
+      "integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.64",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.64.tgz",
+      "integrity": "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "godot-screenshot-server",
+  "version": "1.0.0",
+  "description": "MCP server for capturing screenshots from Windows applications in WSL, specifically targeting Godot Engine",
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsc --watch",
+    "test": "node dist/test.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.1",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.1",
+    "typescript": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ErrorCode,
+  ListToolsRequestSchema,
+  McpError,
+} from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+
+import { 
+  captureWindow, 
+  captureScreen, 
+  checkPowerShellAccess,
+  isWSL 
+} from './screenshot.js';
+import { 
+  findGodotDebugWindows, 
+  findGodotEditorWindows,
+  findWindowByTitle 
+} from './windows.js';
+
+const server = new Server(
+  {
+    name: 'godot-screenshot-server',
+    version: '1.0.0',
+  },
+  {
+    capabilities: {
+      tools: {
+        listChanged: true,
+      },
+    },
+  }
+);
+
+// Tool schemas
+const CaptureGodotDebugSchema = z.object({
+  projectName: z.string().optional().describe('Project name to filter specific debug window'),
+});
+
+const CaptureGodotEditorSchema = z.object({
+  projectName: z.string().optional().describe('Project name to filter specific editor window'),
+});
+
+const CaptureWindowByTitleSchema = z.object({
+  title: z.string().describe('Exact window title to capture'),
+  exact: z.boolean().optional().default(false).describe('Whether to match title exactly'),
+});
+
+
+// Register tool handlers
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: 'capture_godot_debug',
+        description: 'Capture a screenshot of the Godot Debug Game Window',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            projectName: {
+              type: 'string',
+              description: 'Project name to filter specific debug window'
+            }
+          }
+        },
+      },
+      {
+        name: 'capture_godot_editor',
+        description: 'Capture a screenshot of the Godot Scene Editor',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            projectName: {
+              type: 'string',
+              description: 'Project name to filter specific editor window'
+            }
+          }
+        },
+      },
+      {
+        name: 'capture_window_by_title',
+        description: 'Capture a screenshot of any window by its title',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            title: {
+              type: 'string',
+              description: 'Exact window title to capture'
+            },
+            exact: {
+              type: 'boolean',
+              description: 'Whether to match title exactly',
+              default: false
+            }
+          },
+          required: ['title']
+        },
+      },
+      {
+        name: 'capture_fullscreen',
+        description: 'Capture a screenshot of the entire screen',
+        inputSchema: {
+          type: 'object',
+          properties: {}
+        },
+      },
+      {
+        name: 'list_godot_windows',
+        description: 'List all available Godot windows (both editor and debug)',
+        inputSchema: {
+          type: 'object',
+          properties: {}
+        },
+      },
+    ],
+  };
+});
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  try {
+    // Check environment on first use
+    if (!await checkPowerShellAccess()) {
+      throw new McpError(
+        ErrorCode.InternalError,
+        'PowerShell is not accessible from WSL. Please ensure Windows interop is enabled.'
+      );
+    }
+
+    switch (name) {
+      case 'capture_godot_debug': {
+        const { projectName } = CaptureGodotDebugSchema.parse(args);
+        const debugWindows = await findGodotDebugWindows();
+        
+        if (debugWindows.length === 0) {
+          throw new McpError(
+            ErrorCode.InvalidRequest,
+            'No Godot debug windows found. Please ensure the game is running in debug mode.'
+          );
+        }
+        
+        let targetWindow = debugWindows[0];
+        
+        if (projectName && debugWindows.length > 1) {
+          const filtered = debugWindows.find(w => w.title.includes(projectName));
+          if (filtered) {
+            targetWindow = filtered;
+          }
+        }
+        
+        const result = await captureWindow(targetWindow.title);
+        
+        return {
+          content: [
+            {
+              type: 'image',
+              data: result.base64,
+              mimeType: `image/${result.format}`,
+            },
+          ],
+        };
+      }
+
+      case 'capture_godot_editor': {
+        const { projectName } = CaptureGodotEditorSchema.parse(args);
+        const editorWindows = await findGodotEditorWindows();
+        
+        if (editorWindows.length === 0) {
+          throw new McpError(
+            ErrorCode.InvalidRequest,
+            'No Godot editor windows found. Please ensure Godot Engine is running.'
+          );
+        }
+        
+        let targetWindow = editorWindows[0];
+        
+        if (projectName && editorWindows.length > 1) {
+          const filtered = editorWindows.find(w => w.title.includes(projectName));
+          if (filtered) {
+            targetWindow = filtered;
+          }
+        }
+        
+        const result = await captureWindow(targetWindow.title);
+        
+        return {
+          content: [
+            {
+              type: 'image',
+              data: result.base64,
+              mimeType: `image/${result.format}`,
+            },
+          ],
+        };
+      }
+
+      case 'capture_window_by_title': {
+        const { title, exact } = CaptureWindowByTitleSchema.parse(args);
+        
+        const window = await findWindowByTitle(title, exact);
+        
+        if (!window) {
+          throw new McpError(
+            ErrorCode.InvalidRequest,
+            `No window found with title${exact ? ' exactly matching' : ' containing'}: "${title}"`
+          );
+        }
+        
+        const result = await captureWindow(window.title);
+        
+        return {
+          content: [
+            {
+              type: 'image',
+              data: result.base64,
+              mimeType: `image/${result.format}`,
+            },
+          ],
+        };
+      }
+
+      case 'capture_fullscreen': {
+        const result = await captureScreen();
+        
+        return {
+          content: [
+            {
+              type: 'image',
+              data: result.base64,
+              mimeType: `image/${result.format}`,
+            },
+          ],
+        };
+      }
+
+      case 'list_godot_windows': {
+        const [debugWindows, editorWindows] = await Promise.all([
+          findGodotDebugWindows(),
+          findGodotEditorWindows(),
+        ]);
+        
+        const windowList = [
+          '=== Godot Debug Windows ===',
+          ...debugWindows.map(w => `- ${w.title}`),
+          '',
+          '=== Godot Editor Windows ===',
+          ...editorWindows.map(w => `- ${w.title}`),
+        ];
+        
+        if (debugWindows.length === 0 && editorWindows.length === 0) {
+          windowList.push('', 'No Godot windows found.');
+        }
+        
+        return {
+          content: [
+            {
+              type: 'text',
+              text: windowList.join('\n'),
+            },
+          ],
+        };
+      }
+
+      default:
+        throw new McpError(
+          ErrorCode.MethodNotFound,
+          `Unknown tool: ${name}`
+        );
+    }
+  } catch (error) {
+    if (error instanceof McpError) {
+      throw error;
+    }
+    
+    console.error(`Error in tool ${name}:`, error);
+    
+    throw new McpError(
+      ErrorCode.InternalError,
+      `Tool execution failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+});
+
+async function main() {
+  // Check if running in WSL
+  if (!isWSL()) {
+    console.warn('Warning: This server is designed to run in WSL. Some features may not work correctly.');
+  }
+  
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  
+  console.error('Godot Screenshot MCP Server running on stdio transport');
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/src/powershell.ts
+++ b/src/powershell.ts
@@ -71,25 +71,14 @@ if ($width -le 0 -or $height -le 0) {
     throw "Invalid window dimensions: $width x $height"
 }
 
-# Use screen capture from window position instead of PrintWindow for GPU content
-$screenWidth = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Width
-$screenHeight = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Height
-$screenBitmap = New-Object System.Drawing.Bitmap($screenWidth, $screenHeight)
-$screenGraphics = [System.Drawing.Graphics]::FromImage($screenBitmap)
-$screenGraphics.CopyFromScreen(0, 0, 0, 0, $screenBitmap.Size)
-
-# Crop to window area
+# Capture directly from window coordinates (works across multiple monitors)
 $windowBitmap = New-Object System.Drawing.Bitmap($width, $height)
 $windowGraphics = [System.Drawing.Graphics]::FromImage($windowBitmap)
-$sourceRect = New-Object System.Drawing.Rectangle($rect.Left, $rect.Top, $width, $height)
-$destRect = New-Object System.Drawing.Rectangle(0, 0, $width, $height)
-$windowGraphics.DrawImage($screenBitmap, $destRect, $sourceRect, [System.Drawing.GraphicsUnit]::Pixel)
+$windowGraphics.CopyFromScreen($rect.Left, $rect.Top, 0, 0, $windowBitmap.Size)
 
 $windowBitmap.Save('${safePath}')
 $windowGraphics.Dispose()
 $windowBitmap.Dispose()
-$screenGraphics.Dispose()
-$screenBitmap.Dispose()
 Write-Output 'SUCCESS'
 `;
   },

--- a/src/powershell.ts
+++ b/src/powershell.ts
@@ -1,0 +1,23 @@
+// Simple PowerShell commands that are less likely to trigger antivirus
+export const LIST_WINDOWS_COMMAND = `Get-Process | Where-Object {$_.MainWindowTitle -ne ""} | ForEach-Object { Write-Output "$($_.Id)|$($_.MainWindowTitle)" }`;
+
+export const SCREENSHOT_COMMANDS = {
+  listWindows: () => LIST_WINDOWS_COMMAND,
+  
+  captureWindow: (_windowTitle: string, outputPath: string) => 
+    `Add-Type -AssemblyName System.Drawing,System.Windows.Forms; $screen = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds; $bitmap = New-Object System.Drawing.Bitmap $screen.Width,$screen.Height; $graphics = [System.Drawing.Graphics]::FromImage($bitmap); $graphics.CopyFromScreen(0,0,0,0,$bitmap.Size); $bitmap.Save('${outputPath}'); $graphics.Dispose(); $bitmap.Dispose(); Write-Output 'SUCCESS'`,
+
+  captureScreen: (outputPath: string) => 
+    `Add-Type -AssemblyName System.Drawing,System.Windows.Forms; $screen = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds; $bitmap = New-Object System.Drawing.Bitmap $screen.Width,$screen.Height; $graphics = [System.Drawing.Graphics]::FromImage($bitmap); $graphics.CopyFromScreen(0,0,0,0,$bitmap.Size); $bitmap.Save('${outputPath}'); $graphics.Dispose(); $bitmap.Dispose(); Write-Output 'SUCCESS'`
+};
+
+export const NIRCMD_COMMANDS = {
+  captureWindow: (windowTitle: string, outputPath: string) => 
+    `nircmd.exe savescreenshotwin "${windowTitle}" "${outputPath}"`,
+  
+  captureScreen: (outputPath: string) => 
+    `nircmd.exe savescreenshot "${outputPath}"`,
+  
+  listWindows: () => 
+    `nircmd.exe win list`
+};

--- a/src/powershell.ts
+++ b/src/powershell.ts
@@ -1,22 +1,89 @@
 // Simple PowerShell commands that are less likely to trigger antivirus
 export const LIST_WINDOWS_COMMAND = `Get-Process | Where-Object {$_.MainWindowTitle -ne ""} | ForEach-Object { Write-Output "$($_.Id)|$($_.MainWindowTitle)" }`;
 
+// Sanitize paths to prevent command injection
+function sanitizePath(path: string): string {
+  // Remove dangerous characters and validate path format
+  return path.replace(/[;&|`$]/g, '').replace(/'/g, "''");
+}
+
+// Sanitize window titles to prevent injection
+function sanitizeWindowTitle(title: string): string {
+  return title.replace(/'/g, "''").replace(/[;&|`$]/g, '');
+}
+
 export const SCREENSHOT_COMMANDS = {
   listWindows: () => LIST_WINDOWS_COMMAND,
   
-  captureWindow: (_windowTitle: string, outputPath: string) => 
-    `Add-Type -AssemblyName System.Drawing,System.Windows.Forms; $screen = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds; $bitmap = New-Object System.Drawing.Bitmap $screen.Width,$screen.Height; $graphics = [System.Drawing.Graphics]::FromImage($bitmap); $graphics.CopyFromScreen(0,0,0,0,$bitmap.Size); $bitmap.Save('${outputPath}'); $graphics.Dispose(); $bitmap.Dispose(); Write-Output 'SUCCESS'`,
+  captureWindow: (windowTitle: string, outputPath: string) => {
+    const safePath = sanitizePath(outputPath);
+    const safeTitle = sanitizeWindowTitle(windowTitle);
+    return `
+Add-Type -AssemblyName System.Drawing,System.Windows.Forms
+Add-Type -AssemblyName System.Runtime.InteropServices
 
-  captureScreen: (outputPath: string) => 
-    `Add-Type -AssemblyName System.Drawing,System.Windows.Forms; $screen = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds; $bitmap = New-Object System.Drawing.Bitmap $screen.Width,$screen.Height; $graphics = [System.Drawing.Graphics]::FromImage($bitmap); $graphics.CopyFromScreen(0,0,0,0,$bitmap.Size); $bitmap.Save('${outputPath}'); $graphics.Dispose(); $bitmap.Dispose(); Write-Output 'SUCCESS'`
+$signature = @'
+[DllImport("user32.dll")]
+public static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
+[DllImport("user32.dll")]
+public static extern bool GetWindowRect(IntPtr hwnd, out RECT lpRect);
+[DllImport("user32.dll")]
+public static extern bool PrintWindow(IntPtr hwnd, IntPtr hdcBlt, int nFlags);
+public struct RECT { public int Left; public int Top; public int Right; public int Bottom; }
+'@
+
+$User32 = Add-Type -MemberDefinition $signature -Name "User32" -Namespace Win32Functions -PassThru
+
+$hwnd = $User32::FindWindow($null, '${safeTitle}')
+if ($hwnd -eq [IntPtr]::Zero) { 
+    # Try partial match if exact match fails
+    $processes = Get-Process | Where-Object {$_.MainWindowTitle -like "*${safeTitle}*"}
+    if ($processes.Count -gt 0) {
+        $hwnd = $processes[0].MainWindowHandle
+    }
+    if ($hwnd -eq [IntPtr]::Zero) { 
+        throw "Window not found: ${safeTitle}" 
+    }
+}
+
+$rect = New-Object Win32Functions.User32+RECT
+$User32::GetWindowRect($hwnd, [ref]$rect)
+$width = $rect.Right - $rect.Left
+$height = $rect.Bottom - $rect.Top
+
+if ($width -le 0 -or $height -le 0) {
+    throw "Invalid window dimensions: $width x $height"
+}
+
+$bitmap = New-Object System.Drawing.Bitmap $width, $height
+$graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+$hdc = $graphics.GetHdc()
+$User32::PrintWindow($hwnd, $hdc, 0)
+$graphics.ReleaseHdc($hdc)
+$bitmap.Save('${safePath}')
+$graphics.Dispose()
+$bitmap.Dispose()
+Write-Output 'SUCCESS'
+`;
+  },
+
+  captureScreen: (outputPath: string) => {
+    const safePath = sanitizePath(outputPath);
+    return `Add-Type -AssemblyName System.Drawing,System.Windows.Forms; $screen = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds; $bitmap = New-Object System.Drawing.Bitmap $screen.Width,$screen.Height; $graphics = [System.Drawing.Graphics]::FromImage($bitmap); $graphics.CopyFromScreen(0,0,0,0,$bitmap.Size); $bitmap.Save('${safePath}'); $graphics.Dispose(); $bitmap.Dispose(); Write-Output 'SUCCESS'`;
+  }
 };
 
 export const NIRCMD_COMMANDS = {
-  captureWindow: (windowTitle: string, outputPath: string) => 
-    `nircmd.exe savescreenshotwin "${windowTitle}" "${outputPath}"`,
+  captureWindow: (windowTitle: string, outputPath: string) => {
+    const safePath = sanitizePath(outputPath);
+    const safeTitle = sanitizeWindowTitle(windowTitle);
+    return `nircmd.exe savescreenshotwin "${safeTitle}" "${safePath}"`;
+  },
   
-  captureScreen: (outputPath: string) => 
-    `nircmd.exe savescreenshot "${outputPath}"`,
+  captureScreen: (outputPath: string) => {
+    const safePath = sanitizePath(outputPath);
+    return `nircmd.exe savescreenshot "${safePath}"`;
+  },
   
   listWindows: () => 
     `nircmd.exe win list`

--- a/src/powershell.ts
+++ b/src/powershell.ts
@@ -58,10 +58,9 @@ public struct POINT {
 }
 "@
 
-# Bring window to foreground and ensure it's visible
-[Win32]::ShowWindow($hwnd, 9) # SW_RESTORE
+# Gently bring window to foreground without changing its current state
 [Win32]::SetForegroundWindow($hwnd)
-Start-Sleep -Milliseconds 200  # Give time for window to come to front
+Start-Sleep -Milliseconds 50  # Brief pause for focus change
 
 $rect = New-Object RECT
 [Win32]::GetWindowRect($hwnd, [ref]$rect)

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -144,7 +144,7 @@ export async function captureWindow(
     await unlink(tempPath).catch(() => {});
     
     return {
-      base64: `data:image/${format};base64,${base64}`,
+      base64,
       format
     };
   } catch (error) {
@@ -201,7 +201,7 @@ export async function captureScreen(options: ScreenshotOptions = {}): Promise<Sc
     await unlink(tempPath).catch(() => {});
     
     return {
-      base64: `data:image/${format};base64,${base64}`,
+      base64,
       format
     };
   } catch (error) {

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -1,0 +1,228 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { readFile, writeFile, unlink } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { existsSync, readFileSync } from 'fs';
+import { SCREENSHOT_COMMANDS, NIRCMD_COMMANDS } from './powershell.js';
+
+const execAsync = promisify(exec);
+
+export interface ScreenshotOptions {
+  quality?: number;
+  format?: 'png' | 'jpg';
+  useNirCmd?: boolean;
+}
+
+export interface ScreenshotResult {
+  base64: string;
+  width?: number;
+  height?: number;
+  format: string;
+}
+
+// Throttling mechanism
+let lastScreenshotTime = 0;
+const SCREENSHOT_THROTTLE_MS = 500; // Max 2 per second
+
+// Get Windows temp directory for WSL compatibility
+async function getWindowsTempDir(): Promise<string> {
+  if (isWSL()) {
+    try {
+      const { stdout } = await execAsync('powershell.exe -Command "Write-Output $env:TEMP"');
+      const winTempDir = stdout.trim();
+      
+      // Check if we got a valid path (not just ":TEMP")
+      if (winTempDir && winTempDir !== ':TEMP' && winTempDir.includes('\\')) {
+        // Convert Windows path to WSL path
+        const wslPath = winTempDir.replace(/\\/g, '/').replace(/^([A-Z]):/, (_, drive) => `/mnt/${drive.toLowerCase()}`);
+        return wslPath;
+      } else {
+        // Fallback to common Windows temp directory
+        return '/mnt/c/Windows/Temp';
+      }
+    } catch {
+      return '/mnt/c/Windows/Temp';
+    }
+  }
+  return tmpdir();
+}
+
+// Environment configuration
+const CONFIG = {
+  quality: parseInt(process.env.SCREENSHOT_QUALITY || '85'),
+  format: (process.env.SCREENSHOT_FORMAT || 'png') as 'png' | 'jpg',
+  tempDir: process.env.TEMP_DIR || tmpdir(),
+  useNirCmd: process.env.USE_NIRCMD === 'true'
+};
+
+let windowsTempDir: string | null = null;
+
+// WSL detection
+export function isWSL(): boolean {
+  try {
+    return existsSync('/proc/version') && 
+           readFileSync('/proc/version', 'utf8').toLowerCase().includes('microsoft');
+  } catch {
+    return false;
+  }
+}
+
+// Path translation utilities
+export function wslToWindowsPath(wslPath: string): string {
+  return wslPath
+    .replace(/^\/mnt\/([a-z])/, (_, drive) => `${drive.toUpperCase()}:`)
+    .replace(/\//g, '\\');
+}
+
+export function windowsToWslPath(winPath: string): string {
+  return winPath
+    .replace(/^([A-Z]):/, (_, drive) => `/mnt/${drive.toLowerCase()}`)
+    .replace(/\\/g, '/');
+}
+
+async function throttleScreenshot(): Promise<void> {
+  const now = Date.now();
+  const timeSinceLastScreenshot = now - lastScreenshotTime;
+  
+  if (timeSinceLastScreenshot < SCREENSHOT_THROTTLE_MS) {
+    await new Promise(resolve => setTimeout(resolve, SCREENSHOT_THROTTLE_MS - timeSinceLastScreenshot));
+  }
+  
+  lastScreenshotTime = Date.now();
+}
+
+export async function captureWindow(
+  windowTitle: string, 
+  options: ScreenshotOptions = {}
+): Promise<ScreenshotResult> {
+  await throttleScreenshot();
+  
+  // const quality = options.quality || CONFIG.quality;
+  const format = options.format || CONFIG.format;
+  const useNirCmd = options.useNirCmd !== undefined ? options.useNirCmd : CONFIG.useNirCmd;
+  
+  // Initialize Windows temp directory if needed
+  if (!windowsTempDir) {
+    windowsTempDir = await getWindowsTempDir();
+  }
+  
+  const timestamp = Date.now();
+  const filename = `screenshot-${timestamp}.${format}`;
+  const tempPath = join(windowsTempDir, filename);
+  const windowsPath = isWSL() ? wslToWindowsPath(tempPath) : tempPath;
+  
+  try {
+    if (useNirCmd) {
+      const command = NIRCMD_COMMANDS.captureWindow(windowTitle, windowsPath);
+      await execAsync(command, { timeout: 5000 });
+    } else {
+      const script = SCREENSHOT_COMMANDS.captureWindow(windowTitle, windowsPath);
+      const scriptPath = join(windowsTempDir, `capture-${timestamp}.ps1`);
+      await writeFile(scriptPath, script);
+      
+      const command = `powershell.exe -ExecutionPolicy Bypass -File "${wslToWindowsPath(scriptPath)}"`;
+      const { stdout, stderr } = await execAsync(command, { timeout: 5000 });
+      
+      if (stderr || !stdout.includes('SUCCESS')) {
+        throw new Error(`PowerShell error: ${stderr || 'Unknown error'}`);
+      }
+      
+      await unlink(scriptPath).catch(() => {});
+    }
+    
+    // Read the captured image
+    const imageBuffer = await readFile(tempPath);
+    const base64 = imageBuffer.toString('base64');
+    
+    // Clean up
+    await unlink(tempPath).catch(() => {});
+    
+    return {
+      base64,
+      format
+    };
+  } catch (error) {
+    // Clean up on error
+    try {
+      await unlink(tempPath);
+    } catch {}
+    
+    throw new Error(`Failed to capture window "${windowTitle}": ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+export async function captureScreen(options: ScreenshotOptions = {}): Promise<ScreenshotResult> {
+  await throttleScreenshot();
+  
+  // const quality = options.quality || CONFIG.quality;
+  const format = options.format || CONFIG.format;
+  const useNirCmd = options.useNirCmd !== undefined ? options.useNirCmd : CONFIG.useNirCmd;
+  
+  // Initialize Windows temp directory if needed
+  if (!windowsTempDir) {
+    windowsTempDir = await getWindowsTempDir();
+  }
+  
+  const timestamp = Date.now();
+  const filename = `fullscreen-${timestamp}.${format}`;
+  const tempPath = join(windowsTempDir, filename);
+  const windowsPath = isWSL() ? wslToWindowsPath(tempPath) : tempPath;
+  
+  try {
+    if (useNirCmd) {
+      const command = NIRCMD_COMMANDS.captureScreen(windowsPath);
+      await execAsync(command, { timeout: 5000 });
+    } else {
+      const script = SCREENSHOT_COMMANDS.captureScreen(windowsPath);
+      const scriptPath = join(windowsTempDir, `capture-${timestamp}.ps1`);
+      await writeFile(scriptPath, script);
+      
+      const command = `powershell.exe -ExecutionPolicy Bypass -File "${wslToWindowsPath(scriptPath)}"`;
+      const { stdout, stderr } = await execAsync(command, { timeout: 5000 });
+      
+      if (stderr || !stdout.includes('SUCCESS')) {
+        throw new Error(`PowerShell error: ${stderr || 'Unknown error'}`);
+      }
+      
+      await unlink(scriptPath).catch(() => {});
+    }
+    
+    // Read the captured image
+    const imageBuffer = await readFile(tempPath);
+    const base64 = imageBuffer.toString('base64');
+    
+    // Clean up
+    await unlink(tempPath).catch(() => {});
+    
+    return {
+      base64: `data:image/${format};base64,${base64}`,
+      format
+    };
+  } catch (error) {
+    // Clean up on error
+    try {
+      await unlink(tempPath);
+    } catch {}
+    
+    throw new Error(`Failed to capture screen: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+export async function checkPowerShellAccess(): Promise<boolean> {
+  try {
+    const { stdout } = await execAsync('powershell.exe -Command "Write-Output \'OK\'"', { timeout: 2000 });
+    return stdout.trim() === 'OK';
+  } catch {
+    return false;
+  }
+}
+
+export async function checkNirCmdAccess(): Promise<boolean> {
+  try {
+    await execAsync('nircmd.exe help', { timeout: 2000 });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+import { checkPowerShellAccess, checkNirCmdAccess, isWSL } from './screenshot.js';
+import { listWindows, findGodotDebugWindows, findGodotEditorWindows } from './windows.js';
+
+async function runTests(): Promise<void> {
+  console.log('🧪 Godot Screenshot MCP Server - Test Suite\n');
+  
+  // Environment checks
+  console.log('📋 Environment Checks:');
+  console.log(`  WSL Detected: ${isWSL() ? '✅' : '❌'}`);
+  
+  try {
+    const powershellOk = await checkPowerShellAccess();
+    console.log(`  PowerShell Access: ${powershellOk ? '✅' : '❌'}`);
+  } catch (error) {
+    console.log(`  PowerShell Access: ❌ (${error})`);
+  }
+  
+  try {
+    const nircmdOk = await checkNirCmdAccess();
+    console.log(`  NirCmd Access: ${nircmdOk ? '✅' : '❌'}`);
+  } catch (error) {
+    console.log(`  NirCmd Access: ❌ (Optional)`);
+  }
+  
+  console.log();
+  
+  // Window enumeration tests
+  console.log('🪟 Window Enumeration Tests:');
+  
+  try {
+    console.log('  Listing all windows...');
+    const allWindows = await listWindows();
+    console.log(`  Found ${allWindows.length} total windows ✅`);
+    
+    if (allWindows.length > 0) {
+      console.log('  Sample windows:');
+      allWindows.slice(0, 5).forEach(w => {
+        console.log(`    - ${w.title}`);
+      });
+      if (allWindows.length > 5) {
+        console.log(`    ... and ${allWindows.length - 5} more`);
+      }
+    }
+  } catch (error) {
+    console.log(`  Window enumeration: ❌ (${error})`);
+  }
+  
+  console.log();
+  
+  // Godot-specific window tests
+  console.log('🎮 Godot Window Detection:');
+  
+  try {
+    const debugWindows = await findGodotDebugWindows();
+    console.log(`  Debug Windows: ${debugWindows.length > 0 ? '✅' : '⚠️'} (${debugWindows.length} found)`);
+    debugWindows.forEach(w => console.log(`    - ${w.title}`));
+  } catch (error) {
+    console.log(`  Debug Windows: ❌ (${error})`);
+  }
+  
+  try {
+    const editorWindows = await findGodotEditorWindows();
+    console.log(`  Editor Windows: ${editorWindows.length > 0 ? '✅' : '⚠️'} (${editorWindows.length} found)`);
+    editorWindows.forEach(w => console.log(`    - ${w.title}`));
+  } catch (error) {
+    console.log(`  Editor Windows: ❌ (${error})`);
+  }
+  
+  console.log();
+  
+  // Configuration checks
+  console.log('⚙️ Configuration:');
+  console.log(`  SCREENSHOT_QUALITY: ${process.env.SCREENSHOT_QUALITY || '85 (default)'}`);
+  console.log(`  SCREENSHOT_FORMAT: ${process.env.SCREENSHOT_FORMAT || 'png (default)'}`);
+  console.log(`  TEMP_DIR: ${process.env.TEMP_DIR || '/tmp (default)'}`);
+  console.log(`  USE_NIRCMD: ${process.env.USE_NIRCMD === 'true' ? 'true' : 'false (default)'}`);
+  
+  console.log();
+  
+  // Summary
+  console.log('📋 Test Summary:');
+  
+  if (!isWSL()) {
+    console.log('⚠️  Warning: Not running in WSL. Some features may not work correctly.');
+  }
+  
+  const powershellOk = await checkPowerShellAccess().catch(() => false);
+  if (!powershellOk) {
+    console.log('❌ Critical: PowerShell not accessible. Enable Windows interop in WSL.');
+    console.log('   Try: echo 1 | sudo tee /proc/sys/fs/binfmt_misc/WSLInterop');
+    return;
+  }
+  
+  const allWindows = await listWindows().catch(() => []);
+  if (allWindows.length === 0) {
+    console.log('⚠️  Warning: No windows found. Check PowerShell access.');
+  }
+  
+  const [debugWindows, editorWindows] = await Promise.all([
+    findGodotDebugWindows().catch(() => []),
+    findGodotEditorWindows().catch(() => [])
+  ]);
+  
+  if (debugWindows.length === 0 && editorWindows.length === 0) {
+    console.log('⚠️  No Godot windows found. Start Godot Engine to test screenshot capture.');
+  } else {
+    console.log('✅ Ready for screenshot capture!');
+  }
+  
+  console.log();
+  console.log('To test screenshot capture, ensure Godot is running and use the MCP tools.');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runTests().catch(error => {
+    console.error('Test failed:', error);
+    process.exit(1);
+  });
+}

--- a/src/windows.ts
+++ b/src/windows.ts
@@ -1,7 +1,7 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { LIST_WINDOWS_COMMAND } from './powershell.js';
-import { writeFile, unlink, appendFile } from 'fs/promises';
+import { writeFile, unlink } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { wslToWindowsPath, isWSL } from './screenshot.js';
@@ -50,14 +50,12 @@ export async function listWindows(pattern?: string): Promise<WindowInfo[]> {
     await writeFile(scriptPath, LIST_WINDOWS_COMMAND);
     const windowsScriptPath = isWSL() ? wslToWindowsPath(scriptPath) : scriptPath;
     const command = `powershell.exe -ExecutionPolicy Bypass -File "${windowsScriptPath}"`;
-    const debugLog = `[${new Date().toISOString()}] CWD: ${process.cwd()}, ScriptPath: ${scriptPath}, WindowsPath: ${windowsScriptPath}, Command: ${command}\n`;
-    await appendFile('/tmp/mcp-debug.log', debugLog).catch(() => {});
+    // Debug logging disabled for security - contains sensitive paths
     const { stdout, stderr } = await execAsync(command, { timeout: 5000 });
     
     if (stderr) {
-      await appendFile('/tmp/mcp-debug.log', `[${new Date().toISOString()}] PowerShell stderr: ${stderr}\n`).catch(() => {});
+      console.error(`PowerShell stderr: ${stderr}`);
     }
-    await appendFile('/tmp/mcp-debug.log', `[${new Date().toISOString()}] PowerShell stdout: ${stdout}\n`).catch(() => {});
     
     const windows: WindowInfo[] = [];
     const lines = stdout.trim().split('\n');

--- a/src/windows.ts
+++ b/src/windows.ts
@@ -1,0 +1,110 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { LIST_WINDOWS_COMMAND } from './powershell.js';
+import { writeFile, unlink, appendFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { wslToWindowsPath, isWSL } from './screenshot.js';
+
+const execAsync = promisify(exec);
+
+export interface WindowInfo {
+  handle: string;
+  title: string;
+}
+
+interface WindowCache {
+  timestamp: number;
+  windows: WindowInfo[];
+}
+
+const CACHE_DURATION = 5000; // 5 seconds
+let windowCache: Map<string, WindowCache> = new Map();
+
+export async function listWindows(pattern?: string): Promise<WindowInfo[]> {
+  const cacheKey = pattern || 'all';
+  const cached = windowCache.get(cacheKey);
+  
+  if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
+    return cached.windows;
+  }
+  
+  // Use Windows temp directory if in WSL
+  let tempDir = tmpdir();
+  if (isWSL()) {
+    try {
+      const { stdout } = await execAsync('powershell.exe -Command "Write-Output $env:TEMP"');
+      const winTempDir = stdout.trim();
+      if (winTempDir && winTempDir !== ':TEMP' && winTempDir.includes('\\')) {
+        tempDir = winTempDir.replace(/\\/g, '/').replace(/^([A-Z]):/, (_, drive) => `/mnt/${drive.toLowerCase()}`);
+      } else {
+        tempDir = '/mnt/c/Windows/Temp';
+      }
+    } catch {
+      tempDir = '/mnt/c/Windows/Temp';
+    }
+  }
+  const scriptPath = join(tempDir, `list-windows-${Date.now()}.ps1`);
+  
+  try {
+    await writeFile(scriptPath, LIST_WINDOWS_COMMAND);
+    const windowsScriptPath = isWSL() ? wslToWindowsPath(scriptPath) : scriptPath;
+    const command = `powershell.exe -ExecutionPolicy Bypass -File "${windowsScriptPath}"`;
+    const debugLog = `[${new Date().toISOString()}] CWD: ${process.cwd()}, ScriptPath: ${scriptPath}, WindowsPath: ${windowsScriptPath}, Command: ${command}\n`;
+    await appendFile('/tmp/mcp-debug.log', debugLog).catch(() => {});
+    const { stdout, stderr } = await execAsync(command, { timeout: 5000 });
+    
+    if (stderr) {
+      await appendFile('/tmp/mcp-debug.log', `[${new Date().toISOString()}] PowerShell stderr: ${stderr}\n`).catch(() => {});
+    }
+    await appendFile('/tmp/mcp-debug.log', `[${new Date().toISOString()}] PowerShell stdout: ${stdout}\n`).catch(() => {});
+    
+    const windows: WindowInfo[] = [];
+    const lines = stdout.trim().split('\n');
+    
+    for (const line of lines) {
+      const [handle, title] = line.split('|');
+      if (handle && title) {
+        const windowTitle = title.trim();
+        if (!pattern || windowTitle.toLowerCase().includes(pattern.toLowerCase())) {
+          windows.push({ handle, title: windowTitle });
+        }
+      }
+    }
+    
+    windowCache.set(cacheKey, { timestamp: Date.now(), windows });
+    return windows;
+  } catch (error) {
+    throw new Error(`Failed to list windows: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  } finally {
+    try {
+      await unlink(scriptPath);
+    } catch (e) {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+export async function findGodotDebugWindows(): Promise<WindowInfo[]> {
+  const allWindows = await listWindows();
+  return allWindows.filter(w => w.title.includes('(DEBUG)'));
+}
+
+export async function findGodotEditorWindows(): Promise<WindowInfo[]> {
+  const allWindows = await listWindows();
+  return allWindows.filter(w => w.title.endsWith('- Godot Engine'));
+}
+
+export async function findWindowByTitle(title: string, exact: boolean = false): Promise<WindowInfo | null> {
+  const allWindows = await listWindows();
+  
+  if (exact) {
+    return allWindows.find(w => w.title === title) || null;
+  } else {
+    return allWindows.find(w => w.title.includes(title)) || null;
+  }
+}
+
+export function clearWindowCache(): void {
+  windowCache.clear();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
• Implements production-ready Godot Screenshot MCP server
• Captures Godot editor and debug windows with full GPU-rendered content support
• Includes window detection and filtering capabilities
• Provides secure PowerShell integration for Windows screenshot functionality

## Key Features
• **Multi-monitor support** - Works correctly when Godot is on secondary monitors
• **GPU content capture** - Properly captures 3D viewport content using screen capture instead of PrintWindow
• **Security hardened** - Input sanitization prevents command injection attacks
• **Performance optimized** - Caches expensive operations and fixes race conditions
• **Non-intrusive** - Preserves window size when bringing to foreground

## Major Fixes Applied
• ✅ Fixed critical command injection vulnerabilities in PowerShell execution
• ✅ Implemented proper window-specific screenshot capture (was broken)
• ✅ Added comprehensive input validation with length limits
• ✅ Fixed GPU-rendered content capture for 3D viewports
• ✅ Resolved multi-monitor screenshot issues
• ✅ Eliminated window resizing during capture
• ✅ Cached PowerShell access checks for better performance
• ✅ Standardized base64 format for MCP compatibility

## Test Results
- [x] Test MCP server startup and tool registration
- [x] Verify screenshot capture of Godot editor windows ✅ **Working**
- [x] Test debug window screenshot functionality
- [x] Validate window listing and filtering
- [x] Check fullscreen screenshot capability
- [x] Multi-monitor compatibility ✅ **Working**
- [x] GPU-rendered 3D viewport capture ✅ **Working**

🤖 Generated with [Claude Code](https://claude.ai/code)